### PR TITLE
use batching to overcome too many stale sessions issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,7 @@ This model is based on the model described in the
 | `mu:uuid`           | `xsd:string`   | Mu identifier UUID.                                                     |
 | `dct:created`       | `xsd:dateTime` | Creation date of this session.                                          |
 | `muAccount:account` | unspecified    | The account for this session. Usually points to the vendor credentials. |
+
+### Environment Variables
+
+- `SESSION_CLEANUP_BATCH_SIZE`: when logging in or out, the existing sessions for the given session id are removed. In the case of login, this is done to purge existing lingering (possibly stale) sessions. This is done in batches. By default this is set to 150 sessions per batch.

--- a/lib/vendor-login.js
+++ b/lib/vendor-login.js
@@ -6,7 +6,7 @@ import { NAMESPACES as ns } from '../env';
 import * as sjp from 'sparqljson-parse';
 import * as N3 from 'n3';
 const { literal } = N3.DataFactory;
-const BATCH_SIZE = parseInt(env.SESSION_CLEANUP_BATCH_SIZE || "100");
+const BATCH_SIZE = parseInt(env.SESSION_CLEANUP_BATCH_SIZE || "150");
 
 /*
  * Logs a client in: verifies that the API key is correct for the organisation and publisher, removes stale logins, and creates a new session.
@@ -34,15 +34,15 @@ export async function login(store) {
       'Authentication failed, vendor does not have access to the organization or does not exist. If this should not be the case, please contact us at digitaalABB@vlaanderen.be for login credentials.',
     );
 
-  // Remove sessions already linked to the account for the current session, to remove stale sessions.
-  await removeAllSessions(session);
-
   // Create session in the database and capture the details
   const loginDetailsStore = await createSession(
     session,
     publisher,
     organization,
   );
+
+  // Remove sessions already linked to the account for the current session, to remove stale sessions.
+  await removeAllSessions(session);
 
   return loginDetailsStore;
 }
@@ -57,7 +57,7 @@ export async function login(store) {
  * @returns {undefined} Nothing
  */
 export async function logout(session) {
-  return removeAllSessions(session);
+  return removeAllSessions(session, true);
 }
 
 /*
@@ -93,9 +93,10 @@ async function verifyPublisherKeyOrganisation(publisher, key, organization) {
  * @async
  * @function
  * @param {NamedNode} session - Represents a session that is linked to an account where all the session will be removed from.
+ * @param {boolean} [removeSelf=false] - If true, the session itself will also be removed. If false, only the sessions linked to the account are removed.
  * @returns {undefined} Nothing
  */
-async function removeAllSessions(session) {
+async function removeAllSessions(session, removeSelf = false) {
   // NOTE: same note as above about the graphs.
   // Remove all sessions for this account, not just previous session for this session URI, beause we can get stale sessions otherwise.
   // The downside to this approach is that there can only be one client logged in per account (=vendor). Is this even a downside?
@@ -159,34 +160,36 @@ async function removeAllSessions(session) {
     }
   }
 
-  // After removing all sessions, we also remove the session itself, so that it is not lingering around.
-  await mas.updateSudo(`
-    ${env.SPARQL_PREFIXES}
-    DELETE {
-      GRAPH ?g {
-        ?session
-          a session:Session ;
-          muAccount:account ?account ;
-          dct:created ?created ;
-          muAccount:canActOnBehalfOf ?org;
-          mu:uuid ?id .
-      }
-    }
-    WHERE {
-      GRAPH ?g {
-        VALUES ?session {
-          ${safeSession}
+  if(removeSelf){
+    // After removing all sessions, we also remove the session itself, so that it is not lingering around.
+    await mas.updateSudo(`
+      ${env.SPARQL_PREFIXES}
+      DELETE {
+        GRAPH ?g {
+          ?session
+            a session:Session ;
+            muAccount:account ?account ;
+            dct:created ?created ;
+            muAccount:canActOnBehalfOf ?org;
+            mu:uuid ?id .
         }
-
-        ?session
-          muAccount:account ?account ;
-          a session:Session ;
-          muAccount:canActOnBehalfOf ?org;
-          dct:created ?created ;
-          mu:uuid ?id .
       }
-    }
-  `);
+      WHERE {
+        GRAPH ?g {
+          VALUES ?session {
+            ${safeSession}
+          }
+
+          ?session
+            muAccount:account ?account ;
+            a session:Session ;
+            muAccount:canActOnBehalfOf ?org;
+            dct:created ?created ;
+            mu:uuid ?id .
+        }
+      }
+    `);
+  }
 }
 
 /*

--- a/lib/vendor-login.js
+++ b/lib/vendor-login.js
@@ -6,6 +6,7 @@ import { NAMESPACES as ns } from '../env';
 import * as sjp from 'sparqljson-parse';
 import * as N3 from 'n3';
 const { literal } = N3.DataFactory;
+const BATCH_SIZE = parseInt(env.SESSION_CLEANUP_BATCH_SIZE || "100");
 
 /*
  * Logs a client in: verifies that the API key is correct for the organisation and publisher, removes stale logins, and creates a new session.
@@ -98,7 +99,68 @@ async function removeAllSessions(session) {
   // NOTE: same note as above about the graphs.
   // Remove all sessions for this account, not just previous session for this session URI, beause we can get stale sessions otherwise.
   // The downside to this approach is that there can only be one client logged in per account (=vendor). Is this even a downside?
-  return mas.updateSudo(`
+
+  // somehow, a lot of sessions were found by this query (e.g. in LMB 20250730), which resulted in this call failing.
+  // so we're batching it now and this avoids the issue.
+  let batch = undefined;
+  const parser = new sjp.SparqlJsonParser();
+  const safeSession = rst.termToString(session);
+  while(batch === undefined || batch.length > 0) {
+    const batchResult = await mas.querySudo(`
+      ${env.SPARQL_PREFIXES}
+      SELECT DISTINCT ?session WHERE {
+        GRAPH ?g {
+          ${safeSession}
+            a session:Session ;
+            muAccount:account ?account .
+
+          ?session
+            a session:Session ;
+            muAccount:account ?account ;
+            muAccount:canActOnBehalfOf ?org;
+            mu:uuid ?id .
+
+          FILTER (?session != ${safeSession}).
+        }
+      } LIMIT ${BATCH_SIZE}
+    `);
+    const parsedResults = parser.parseJsonResults(batchResult);
+    batch = parsedResults.map((result) => result.session);
+    if( batch.length > 0 ){
+      const safeBatchExceptTarget = batch.map((s) => rst.termToString(s))
+        .join('\n');
+      await mas.updateSudo(`
+      ${env.SPARQL_PREFIXES}
+      DELETE {
+        GRAPH ?g {
+          ?session
+            a session:Session ;
+            muAccount:account ?account ;
+            dct:created ?created ;
+            muAccount:canActOnBehalfOf ?org;
+            mu:uuid ?id .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          VALUES ?session {
+            ${safeBatchExceptTarget}
+          }
+
+          ?session
+            muAccount:account ?account ;
+            a session:Session ;
+            muAccount:canActOnBehalfOf ?org;
+            dct:created ?created ;
+            mu:uuid ?id .
+        }
+      }
+    `);
+    }
+  }
+
+  // After removing all sessions, we also remove the session itself, so that it is not lingering around.
+  await mas.updateSudo(`
     ${env.SPARQL_PREFIXES}
     DELETE {
       GRAPH ?g {
@@ -112,9 +174,9 @@ async function removeAllSessions(session) {
     }
     WHERE {
       GRAPH ?g {
-        ${rst.termToString(session)}
-          a session:Session ;
-          muAccount:account ?account .
+        VALUES ?session {
+          ${safeSession}
+        }
 
         ?session
           muAccount:account ?account ;


### PR DESCRIPTION
## How to test

- Use a prod dump of LMB for testing, as this data contains the issue
- Log in as a vendor that has many sessions (there is one with 11k)
- See that after this login (can take a while as it needs to clean up a lot) only one session remains
- Log in again (don't log out), still one session remains
- Log in with a different vendor, both vendors have one session
- Log out (no sessions remain for this vendor, but the other vendor's session is still there)
- Log in again (only one session remains, other vendor's session still there)